### PR TITLE
adding jacoco xml output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,4 +24,10 @@ sonarqube {
     }
 }
 
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+}
+
 tasks['sonarqube'].dependsOn test


### PR DESCRIPTION
Adding xml output to jacoco output.  This is necessary for code coverage to appear in sonarqube now.